### PR TITLE
Adopt wheezy fixes (several CVEs and few bugs)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+libpng (1.2.49-1maemo1+0cssu4) unstable; urgency=high
+
+  * Add CVE-2015-7981.patch patch.
+    CVE-2015-7981: Out-of-bounds read in png_convert_to_rfc1123.
+    (Closes: #803078)
+  * Add Prevent-writing-over-length-PLTE-chunk-Cosm.patch patch.
+    CVE-2015-8126: Multiple buffer overflows in the png_set_PLTE and
+    png_get_PLTE functions. (Closes: #805113)
+  * Add Fixed-new-bug-with-CRC-error-after-reading-.patch patch.
+    Fixed new bug with CRC error after reading an over-length palette.
+  * Add patches to address CVE-2015-8472.
+    CVE-2015-8472: Incomplete fix for callers on png_set_PLTE.
+    (Closes: #807112)
+  * Add CVE-2015-8540.patch patch.
+    CVE-2015-8540: underflow read in png_check_keyword(). (Closes: #807694)
+
+ -- Ludek Finstrle <luf@seznam.cz>  Sun,  7 Feb 2016 23:53:05 +0100
+
 libpng (1.2.49-1maemo1+0cssu3) unstable; urgency=low
 
   * add APNG support
@@ -9,14 +27,14 @@ libpng (1.2.49-1maemo1+0cssu2) unstable; urgency=low
   * Backport ARM NEON optimizations from
     libpng.sourceforge.net - ~30% faster decoding
 
- -- Ludek Finstrle <luf@pzkagis.cz>  Fri, 28 Dec 2012 20:30:40 +0100
+ -- Ludek Finstrle <luf@seznam.cz>  Fri, 28 Dec 2012 20:30:40 +0100
 
 libpng (1.2.49-1maemo1+0cssu1) unstable; urgency=high
 
   * Repackage for maemo
   * Several CVE fixes since last maemo package (1.2.37-1)
 
- -- Ludek Finstrle <luf@pzkagis.cz>  Wed, 19 Dec 2012 23:06:31 +0100
+ -- Ludek Finstrle <luf@seznam.cz>  Wed, 19 Dec 2012 23:06:31 +0100
 
 libpng (1.2.49-1) unstable; urgency=high
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: libpng
 Section: libs
 Priority: optional
-Maintainer: Ludek Finstrle <luf@pzkagis.cz>
+Maintainer: Ludek Finstrle <luf@seznam.cz>
 XSBC-Original-Maintainer: Anibal Monsalve Salazar <anibal@debian.org>
 Build-Depends: debhelper (>= 5), libtool, automake, autoconf, quilt (>= 0.40), zlib1g-dev, mawk
 Standards-Version: 3.8.0

--- a/debian/patches/CVE-2015-7981.patch
+++ b/debian/patches/CVE-2015-7981.patch
@@ -1,0 +1,65 @@
+Description: Added a safety check in png_set_tIME()
+Origin: upstream, https://github.com/glennrp/libpng/commit/fbf0f024346ca0a4ffc64b082a95c6b6bb6d29c4
+Bug: http://sourceforge.net/p/libpng/bugs/241/
+Bug-Debian: https://bugs.debian.org/803078 
+Forwarded: not-needed
+Author: Glenn Randers-Pehrson <glennrp@users.sourceforge.net>
+Last-Update: 2015-11-17
+Applied-Upstream: v1.2.54
+
+---
+--- a/png.c
++++ b/png.c
+@@ -675,6 +675,7 @@ png_convert_to_rfc1123(png_structp png_p
+ 
+    if (png_ptr == NULL)
+       return (NULL);
++
+    if (png_ptr->time_buffer == NULL)
+    {
+       png_ptr->time_buffer = (png_charp)png_malloc(png_ptr, (png_uint_32)(29*
+@@ -685,7 +686,7 @@ png_convert_to_rfc1123(png_structp png_p
+    {
+       wchar_t time_buf[29];
+       wsprintf(time_buf, TEXT("%d %S %d %02d:%02d:%02d +0000"),
+-          ptime->day % 32, short_months[(ptime->month - 1) % 12],
++          ptime->day % 32, short_months[(ptime->month - 1U) % 12],
+         ptime->year, ptime->hour % 24, ptime->minute % 60,
+           ptime->second % 61);
+       WideCharToMultiByte(CP_ACP, 0, time_buf, -1, png_ptr->time_buffer,
+@@ -696,7 +697,7 @@ png_convert_to_rfc1123(png_structp png_p
+    {
+       char near_time_buf[29];
+       png_snprintf6(near_time_buf, 29, "%d %s %d %02d:%02d:%02d +0000",
+-          ptime->day % 32, short_months[(ptime->month - 1) % 12],
++          ptime->day % 32, short_months[(ptime->month - 1U) % 12],
+           ptime->year, ptime->hour % 24, ptime->minute % 60,
+           ptime->second % 61);
+       png_memcpy(png_ptr->time_buffer, near_time_buf,
+@@ -704,7 +705,7 @@ png_convert_to_rfc1123(png_structp png_p
+    }
+ #else
+    png_snprintf6(png_ptr->time_buffer, 29, "%d %s %d %02d:%02d:%02d +0000",
+-       ptime->day % 32, short_months[(ptime->month - 1) % 12],
++       ptime->day % 32, short_months[(ptime->month - 1U) % 12],
+        ptime->year, ptime->hour % 24, ptime->minute % 60,
+        ptime->second % 61);
+ #endif
+--- a/pngset.c
++++ b/pngset.c
+@@ -835,6 +835,15 @@ png_set_tIME(png_structp png_ptr, png_in
+        (png_ptr->mode & PNG_WROTE_tIME))
+       return;
+ 
++   if (mod_time->month == 0   || mod_time->month > 12  ||
++       mod_time->day   == 0   || mod_time->day   > 31  ||
++       mod_time->hour  > 23   || mod_time->minute > 59 ||
++       mod_time->second > 60)
++   {
++      png_warning(png_ptr, "Ignoring invalid time value");
++      return;
++   }
++
+    png_memcpy(&(info_ptr->mod_time), mod_time, png_sizeof(png_time));
+    info_ptr->valid |= PNG_INFO_tIME;
+ }

--- a/debian/patches/CVE-2015-8472/0001-Avoid-potential-pointer-overflow-in-png_han.patch
+++ b/debian/patches/CVE-2015-8472/0001-Avoid-potential-pointer-overflow-in-png_han.patch
@@ -1,0 +1,56 @@
+From 7e1ca9ceba4e64259863efdd98bab9b55bdc0b9c Mon Sep 17 00:00:00 2001
+From: Glenn Randers-Pehrson <glennrp at users.sourceforge.net>
+Date: Fri, 13 Nov 2015 23:07:39 -0600
+Subject: [PATCH] [libpng12] Avoid potential pointer overflow in
+ png_handle_iTXt(),
+
+png_handle_zTXt(), png_handle_sPLT(), and png_handle_pCAL() (Bug report
+by John Regehr).
+---
+--- a/pngrutil.c
++++ b/pngrutil.c
+@@ -1108,7 +1108,7 @@ png_handle_iCCP(png_structp png_ptr, png
+    /* There should be at least one zero (the compression type byte)
+     * following the separator, and we should be on it
+     */
+-   if ( profile >= png_ptr->chunkdata + slength - 1)
++   if (slength < 1 ||  profile >= png_ptr->chunkdata + slength - 1)
+    {
+       png_free(png_ptr, png_ptr->chunkdata);
+       png_ptr->chunkdata = NULL;
+@@ -1236,7 +1236,7 @@ png_handle_sPLT(png_structp png_ptr, png
+    ++entry_start;
+ 
+    /* A sample depth should follow the separator, and we should be on it  */
+-   if (entry_start > (png_bytep)png_ptr->chunkdata + slength - 2)
++   if (slength < 2 || entry_start > (png_bytep)png_ptr->chunkdata + slength - 2)
+    {
+       png_free(png_ptr, png_ptr->chunkdata);
+       png_ptr->chunkdata = NULL;
+@@ -1710,7 +1710,7 @@ png_handle_pCAL(png_structp png_ptr, png
+ 
+    /* We need to have at least 12 bytes after the purpose string
+       in order to get the parameter information. */
+-   if (endptr <= buf + 12)
++   if (slength < 12 || endptr <= buf + 12)
+    {
+       png_warning(png_ptr, "Invalid pCAL data");
+       png_free(png_ptr, png_ptr->chunkdata);
+@@ -2166,7 +2166,7 @@ png_handle_zTXt(png_structp png_ptr, png
+       /* Empty loop */ ;
+ 
+    /* zTXt must have some text after the chunkdataword */
+-   if (text >= png_ptr->chunkdata + slength - 2)
++   if (slength < 2 || text >= png_ptr->chunkdata + slength - 2)
+    {
+       png_warning(png_ptr, "Truncated zTXt chunk");
+       png_free(png_ptr, png_ptr->chunkdata);
+@@ -2292,7 +2292,7 @@ png_handle_iTXt(png_structp png_ptr, png
+     * keyword
+     */
+ 
+-   if (lang >= png_ptr->chunkdata + slength - 3)
++   if (slength < 3 || lang >= png_ptr->chunkdata + slength - 3)
+    {
+       png_warning(png_ptr, "Truncated iTXt chunk");
+       png_free(png_ptr, png_ptr->chunkdata);

--- a/debian/patches/CVE-2015-8472/0002-Use-unsigned-constants-in-buffer-length-com.patch
+++ b/debian/patches/CVE-2015-8472/0002-Use-unsigned-constants-in-buffer-length-com.patch
@@ -1,0 +1,58 @@
+From 4488a96126bbefda51d07835411d8e847a88b2b7 Mon Sep 17 00:00:00 2001
+From: Glenn Randers-Pehrson <glennrp at users.sourceforge.net>
+Date: Sat, 21 Nov 2015 14:35:23 -0600
+Subject: [PATCH] [libpng12] Use unsigned constants in buffer length
+ comparisons
+
+---
+ pngrutil.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+--- a/pngrutil.c
++++ b/pngrutil.c
+@@ -1108,7 +1108,7 @@ png_handle_iCCP(png_structp png_ptr, png
+    /* There should be at least one zero (the compression type byte)
+     * following the separator, and we should be on it
+     */
+-   if (slength < 1 ||  profile >= png_ptr->chunkdata + slength - 1)
++   if (slength < 1U ||  profile >= png_ptr->chunkdata + slength - 1U)
+    {
+       png_free(png_ptr, png_ptr->chunkdata);
+       png_ptr->chunkdata = NULL;
+@@ -1236,7 +1236,8 @@ png_handle_sPLT(png_structp png_ptr, png
+    ++entry_start;
+ 
+    /* A sample depth should follow the separator, and we should be on it  */
+-   if (slength < 2 || entry_start > (png_bytep)png_ptr->chunkdata + slength - 2)
++   if (slength < 2U ||
++       entry_start > (png_bytep)png_ptr->chunkdata + slength - 2U)
+    {
+       png_free(png_ptr, png_ptr->chunkdata);
+       png_ptr->chunkdata = NULL;
+@@ -1710,7 +1711,7 @@ png_handle_pCAL(png_structp png_ptr, png
+ 
+    /* We need to have at least 12 bytes after the purpose string
+       in order to get the parameter information. */
+-   if (slength < 12 || endptr <= buf + 12)
++   if (slength < 12U || endptr - buf <= 12)
+    {
+       png_warning(png_ptr, "Invalid pCAL data");
+       png_free(png_ptr, png_ptr->chunkdata);
+@@ -2166,7 +2167,7 @@ png_handle_zTXt(png_structp png_ptr, png
+       /* Empty loop */ ;
+ 
+    /* zTXt must have some text after the chunkdataword */
+-   if (slength < 2 || text >= png_ptr->chunkdata + slength - 2)
++   if (slength < 2U || text >= png_ptr->chunkdata + slength - 2U)
+    {
+       png_warning(png_ptr, "Truncated zTXt chunk");
+       png_free(png_ptr, png_ptr->chunkdata);
+@@ -2292,7 +2293,7 @@ png_handle_iTXt(png_structp png_ptr, png
+     * keyword
+     */
+ 
+-   if (slength < 3 || lang >= png_ptr->chunkdata + slength - 3)
++   if (slength < 3U || lang >= png_ptr->chunkdata + slength - 3U)
+    {
+       png_warning(png_ptr, "Truncated iTXt chunk");
+       png_free(png_ptr, png_ptr->chunkdata);

--- a/debian/patches/CVE-2015-8472/0003-Fixed-bug-recently-introduced-in-png_set_PL.patch
+++ b/debian/patches/CVE-2015-8472/0003-Fixed-bug-recently-introduced-in-png_set_PL.patch
@@ -1,0 +1,21 @@
+From ad224c6907e8a274f2679eae4c2e3085fdc7e8c8 Mon Sep 17 00:00:00 2001
+From: Glenn Randers-Pehrson <glennrp at users.sourceforge.net>
+Date: Sun, 22 Nov 2015 20:24:03 -0600
+Subject: [PATCH] [libpng12] Fixed bug recently introduced in png_set_PLTE()
+ that uses png_ptr
+
+not info_ptr.
+---
+--- a/pngset.c
++++ b/pngset.c
+@@ -453,8 +453,8 @@ png_set_PLTE(png_structp png_ptr, png_in
+    if (png_ptr == NULL || info_ptr == NULL)
+       return;
+ 
+-   max_palette_length = (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE) ?
+-      (1 << png_ptr->bit_depth) : PNG_MAX_PALETTE_LENGTH;
++   max_palette_length = (info_ptr->color_type == PNG_COLOR_TYPE_PALETTE) ?
++      (1 << info_ptr->bit_depth) : PNG_MAX_PALETTE_LENGTH;
+ 
+    if (num_palette < 0 || num_palette > (int) max_palette_length)
+    {

--- a/debian/patches/CVE-2015-8540.patch
+++ b/debian/patches/CVE-2015-8540.patch
@@ -1,0 +1,25 @@
+Description: CVE-2015-8540: underflow read in png_check_keyword()
+Origin: upstream, https://github.com/glennrp/libpng/commit/520b373ee53e92dce93917fea5a609b2a0291472
+Bug: http://sourceforge.net/p/libpng/bugs/244/
+Bug-Debian: https://bugs.debian.org/807694
+Forwarded: not-needed
+Author: Salvatore Bonaccorso <carnil@debian.org>
+Last-Update: 2016-01-07
+Applied-Upstream: v1.2.56
+
+diff --git a/pngwutil.c b/pngwutil.c
+index bc6c986..182f8db 100644
+--- a/pngwutil.c
++++ b/pngwutil.c
+@@ -1285,7 +1285,7 @@ png_check_keyword(png_structp png_ptr, png_charp key, png_charpp new_key)
+    {
+       png_warning(png_ptr, "trailing spaces removed from keyword");
+ 
+-      while (*kp == ' ')
++      while (key_len && *kp == ' ')
+       {
+          *(kp--) = '\0';
+          key_len--;
+-- 
+2.6.4
+

--- a/debian/patches/Fixed-new-bug-with-CRC-error-after-reading-.patch
+++ b/debian/patches/Fixed-new-bug-with-CRC-error-after-reading-.patch
@@ -1,0 +1,21 @@
+Description: Fixed new bug with CRC error after reading an over-length palette
+Origin: upstream, https://github.com/glennrp/libpng/commit/3939689e7d9d06ee05411210bc8e605adcff294e
+Forwarded: not-needed
+Author: Glenn Randers-Pehrson <glennrp@users.sourceforge.net>
+Last-Update: 2015-11-17
+Applied-Upstream: v1.2.54
+---
+ pngrutil.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/pngrutil.c
++++ b/pngrutil.c
+@@ -600,7 +600,7 @@ png_handle_PLTE(png_structp png_ptr, png
+    if (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE)
+ #endif
+    {
+-      png_crc_finish(png_ptr, 0);
++      png_crc_finish(png_ptr, (int) length - num * 3);
+    }
+ #ifndef PNG_READ_OPT_PLTE_SUPPORTED
+    else if (png_crc_error(png_ptr))  /* Only if we have a CRC error */

--- a/debian/patches/Prevent-writing-over-length-PLTE-chunk-Cosm.patch
+++ b/debian/patches/Prevent-writing-over-length-PLTE-chunk-Cosm.patch
@@ -1,0 +1,101 @@
+Description: Multiple buffer overflows in the png_set_PLTE and png_get_PLTE functions
+ .
+ Prevent writing over-length PLTE chunk. Silently truncate over-length
+ PLTE chunk while reading
+ .
+ CVE-2015-8126
+Origin: upstream, https://github.com/glennrp/libpng/commit/475bab6170f651b9863e9fc1b8ffd6cd89a45aa0
+Bug-Debian: https://bugs.debian.org/805113
+Forwarded: not-needed
+Author: Glenn Randers-Pehrson <glennrp@users.sourceforge.net>
+Last-Update: 2015-11-17
+Applied-Upstream: v1.2.54
+---
+--- a/pngrutil.c
++++ b/pngrutil.c
+@@ -503,7 +503,7 @@ void /* PRIVATE */
+ png_handle_PLTE(png_structp png_ptr, png_infop info_ptr, png_uint_32 length)
+ {
+    png_color palette[PNG_MAX_PALETTE_LENGTH];
+-   int num, i;
++   int max_palette_length, num, i;
+ #ifdef PNG_POINTER_INDEXING_SUPPORTED
+    png_colorp pal_ptr;
+ #endif
+@@ -555,8 +555,19 @@ png_handle_PLTE(png_structp png_ptr, png
+       }
+    }
+ 
++   max_palette_length = (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE) ?
++      (1 << png_ptr->bit_depth) : PNG_MAX_PALETTE_LENGTH;
++
++   /* The cast is safe because 'length' is less than 3*PNG_MAX_PALETTE_LENGTH */
+    num = (int)length / 3;
+ 
++   /* If the palette has 256 or fewer entries but is too large for the bit depth,
++    * we don't issue an error, to preserve the behavior of previous libpng versions.
++    * We silently truncate the unused extra palette entries here.
++    */
++   if (num > max_palette_length)
++      num = max_palette_length;
++
+ #ifdef PNG_POINTER_INDEXING_SUPPORTED
+    for (i = 0, pal_ptr = palette; i < num; i++, pal_ptr++)
+    {
+--- a/pngset.c
++++ b/pngset.c
+@@ -446,12 +446,17 @@ png_set_PLTE(png_structp png_ptr, png_in
+    png_colorp palette, int num_palette)
+ {
+ 
++   png_uint_32 max_palette_length;
++
+    png_debug1(1, "in %s storage function", "PLTE");
+ 
+    if (png_ptr == NULL || info_ptr == NULL)
+       return;
+ 
+-   if (num_palette < 0 || num_palette > PNG_MAX_PALETTE_LENGTH)
++   max_palette_length = (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE) ?
++      (1 << png_ptr->bit_depth) : PNG_MAX_PALETTE_LENGTH;
++
++   if (num_palette < 0 || num_palette > (int) max_palette_length)
+    {
+       if (info_ptr->color_type == PNG_COLOR_TYPE_PALETTE)
+          png_error(png_ptr, "Invalid palette length");
+@@ -471,8 +476,8 @@ png_set_PLTE(png_structp png_ptr, png_in
+ #endif
+ 
+    /* Changed in libpng-1.2.1 to allocate PNG_MAX_PALETTE_LENGTH instead
+-    * of num_palette entries, in case of an invalid PNG file that has
+-    * too-large sample values.
++    * of num_palette entries, in case of an invalid PNG file or incorrect
++    * call to png_set_PLTE() with too-large sample values.
+     */
+    png_ptr->palette = (png_colorp)png_calloc(png_ptr,
+       PNG_MAX_PALETTE_LENGTH * png_sizeof(png_color));
+--- a/pngwutil.c
++++ b/pngwutil.c
+@@ -575,17 +575,20 @@ png_write_PLTE(png_structp png_ptr, png_
+ #ifdef PNG_USE_LOCAL_ARRAYS
+    PNG_PLTE;
+ #endif
+-   png_uint_32 i;
++   png_uint_32 max_palette_length, i;
+    png_colorp pal_ptr;
+    png_byte buf[3];
+ 
+    png_debug(1, "in png_write_PLTE");
+ 
++   max_palette_length = (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE) ?
++      (1 << png_ptr->bit_depth) : PNG_MAX_PALETTE_LENGTH;
++
+    if ((
+ #ifdef PNG_MNG_FEATURES_SUPPORTED
+         !(png_ptr->mng_features_permitted & PNG_FLAG_MNG_EMPTY_PLTE) &&
+ #endif
+-        num_pal == 0) || num_pal > 256)
++        num_pal == 0) || num_pal > max_palette_length)
+    {
+      if (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE)
+      {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,4 +1,8 @@
 01-legacy.patch
+CVE-2015-7981.patch
+Prevent-writing-over-length-PLTE-chunk-Cosm.patch
+Fixed-new-bug-with-CRC-error-after-reading-.patch
+
 51-maemo-pngconf.patch
 52-maemo-read_filter-neon.patch
 libpng-1.2.49-apng.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,6 +2,10 @@
 CVE-2015-7981.patch
 Prevent-writing-over-length-PLTE-chunk-Cosm.patch
 Fixed-new-bug-with-CRC-error-after-reading-.patch
+CVE-2015-8472/0001-Avoid-potential-pointer-overflow-in-png_han.patch
+CVE-2015-8472/0002-Use-unsigned-constants-in-buffer-length-com.patch
+CVE-2015-8472/0003-Fixed-bug-recently-introduced-in-png_set_PL.patch
+CVE-2015-8540.patch
 
 51-maemo-pngconf.patch
 52-maemo-read_filter-neon.patch


### PR DESCRIPTION
- Add CVE-2015-7981.patch patch.
  CVE-2015-7981: Out-of-bounds read in png_convert_to_rfc1123.
  (Closes: #803078)
- Add Prevent-writing-over-length-PLTE-chunk-Cosm.patch patch.
  CVE-2015-8126: Multiple buffer overflows in the png_set_PLTE and
  png_get_PLTE functions. (Closes: #805113)
- Add Fixed-new-bug-with-CRC-error-after-reading-.patch patch.
  Fixed new bug with CRC error after reading an over-length palette.
- Add patches to address CVE-2015-8472.
  CVE-2015-8472: Incomplete fix for callers on png_set_PLTE.
  (Closes: #807112)
- Add CVE-2015-8540.patch patch.
  CVE-2015-8540: underflow read in png_check_keyword(). (Closes: #807694)
